### PR TITLE
converting mask in case not in int16

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -194,6 +194,7 @@ process FW_Corrected_Metrics {
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
+    scil_image_math.py convert $brain_mask $brain_mask -f --data_type int16
     scil_compute_dti_metrics.py $fw_corrected_dwi $bval $bvec --mask $brain_mask\
         --ad ${sid}__fw_corr_ad.nii.gz --evecs ${sid}__fw_corr_evecs.nii.gz\
         --evals ${sid}__fw_corr_evals.nii.gz --fa ${sid}__fw_corr_fa.nii.gz\


### PR DESCRIPTION
Fix if the mask is not in int16. I was using the t1_warped_mask from tractoflow, which seems to be in float64...