### PR TITLE
lambda2 default changed

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
     perp_diff_min=0.1e-3
     perp_diff_max=0.7e-3
     lambda1=0
-    lambda2=1e-3
+    lambda2=0.25
     b_thr=40
 }
 


### PR DESCRIPTION
Following on the scilpy PR. Just changing default lambda2 to be more robust to several datasets analyzed recently (ADNI, myelo-inferno).